### PR TITLE
VOOD-169: Refactor graphViz and plantUml exports.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       },
       "engines": {
         "node": "^16",
-        "vscode": "^1.61.0"
+        "vscode": "^1.66.0"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {

--- a/src/object-diagram/logic/logic.spec.ts
+++ b/src/object-diagram/logic/logic.spec.ts
@@ -116,7 +116,7 @@ describe('Object diagram logic', () => {
               shouldReadTheObjectDiagramCorrectlyFromSource(
                 'a panel view input',
                 new PanelViewInputObjectDiagramReader(),
-                panelViewInput,
+                panelViewInput.callstack[0].variables,
                 objectDiagram
               );
               //  Writer tests

--- a/src/object-diagram/logic/reader/panelViewInputObjectDiagramReader.ts
+++ b/src/object-diagram/logic/reader/panelViewInputObjectDiagramReader.ts
@@ -1,5 +1,5 @@
-import { PanelViewInput, VariableRelation } from '../../../model/panelViewInput';
-import { EscapedString, escapeString } from '../../model/escapedString';
+import { PanelViewInputVariableMap, VariableRelation } from '../../../model/panelViewInput';
+import { escapeString } from '../../model/escapedString';
 import { Field } from '../../model/field';
 import { ObjectDiagram } from '../../model/objectDiagram';
 import { isPrimitiveJavaType, PrimitiveJavaType } from '../../model/primitiveJavaType';
@@ -11,14 +11,12 @@ import { ObjectDiagramReader } from './objectDiagramReader';
 const isUndefinedOrPrimitiveJavaType = (type: string | undefined): type is undefined | PrimitiveJavaType =>
   type === undefined || isPrimitiveJavaType(type);
 
-export class PanelViewInputObjectDiagramReader implements ObjectDiagramReader<PanelViewInput> {
-  read({ callstack }: PanelViewInput): ObjectDiagram {
-    const variables = callstack[0].variables;
+export class PanelViewInputObjectDiagramReader implements ObjectDiagramReader<PanelViewInputVariableMap> {
+  read(variables: PanelViewInputVariableMap): ObjectDiagram {
     const stackFrameId = '__stackFrame__';
     const structures: Structure[] = [
       {
         id: createStructureId(stackFrameId),
-        name: '[StackFrame]' as EscapedString,
         type: '[StackFrame]',
       },
     ];
@@ -30,8 +28,6 @@ export class PanelViewInputObjectDiagramReader implements ObjectDiagramReader<Pa
         const structure: Structure = {
           id: structureId,
           type,
-          //  Escape string representations that contain field values (e.g. for Java records)
-          name: escapeString(id),
         };
         switch (value) {
           case undefined:
@@ -98,7 +94,7 @@ export class PanelViewInputObjectDiagramReader implements ObjectDiagramReader<Pa
           references.push({
             startId: createStructureId(relationName ? parentId : stackFrameId),
             endId: structureId,
-            name: relationName || parentId,
+            name: relationName || (variables.get(parentId)?.name as string),
           });
         });
       }

--- a/src/object-diagram/logic/test-suites/linked-list/tests/0/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/0/object-diagram.json
@@ -2,19 +2,16 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602",
-      "type": "LinkedList",
-      "name": "LinkedList@9"
+      "type": "LinkedList"
     }
   ],
   "fields": [

--- a/src/object-diagram/logic/test-suites/linked-list/tests/0/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/0/writer/expected.gv
@@ -1,18 +1,18 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">list</td><td align="left" port="list"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList@9</b><br/><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
     <tr><td align="left">head</td><td align="left" port="head">null</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label="list"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
 }

--- a/src/object-diagram/logic/test-suites/linked-list/tests/0/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/0/writer/expected.puml
@@ -1,14 +1,14 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   args =>
   list =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-map "LinkedList@9" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 <<LinkedList>> {
+map "<<LinkedList>>" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 {
   head => null
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 : list
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
 @enduml

--- a/src/object-diagram/logic/test-suites/linked-list/tests/1/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/1/object-diagram.json
@@ -2,29 +2,24 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602",
-      "type": "LinkedList",
-      "name": "LinkedList@9"
+      "type": "LinkedList"
     },
     {
       "id": "_228d691985f93beaed469d085317435fb3665ef9",
-      "type": "LinkedList$Node",
-      "name": "LinkedList$Node@17"
+      "type": "LinkedList$Node"
     },
     {
       "id": "_25f504355ec07b115120e557c385e256ddbe8e4e",
       "type": "String",
-      "name": "\"1\"",
       "value": "\"1\""
     }
   ],

--- a/src/object-diagram/logic/test-suites/linked-list/tests/1/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/1/writer/expected.gv
@@ -1,29 +1,29 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">list</td><td align="left" port="list"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList@9</b><br/><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
     <tr><td align="left">head</td><td align="left" port="head"></td></tr>
   </table>>]
   _228d691985f93beaed469d085317435fb3665ef9 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList$Node@17</b><br/><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
     <tr><td align="left">next</td><td align="left" port="next">null</td></tr>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
   </table>>]
   _25f504355ec07b115120e557c385e256ddbe8e4e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"1"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"1"</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label="list"]
-  _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602:head -> _228d691985f93beaed469d085317435fb3665ef9 [label="head"]
-  _228d691985f93beaed469d085317435fb3665ef9:value -> _25f504355ec07b115120e557c385e256ddbe8e4e [label="value"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
+  _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602:head -> _228d691985f93beaed469d085317435fb3665ef9
+  _228d691985f93beaed469d085317435fb3665ef9:value -> _25f504355ec07b115120e557c385e256ddbe8e4e
 }

--- a/src/object-diagram/logic/test-suites/linked-list/tests/1/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/1/writer/expected.puml
@@ -1,23 +1,23 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   args =>
   list =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-map "LinkedList@9" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 <<LinkedList>> {
+map "<<LinkedList>>" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 {
   head =>
 }
-map "LinkedList$Node@17" as _228d691985f93beaed469d085317435fb3665ef9 <<LinkedList$Node>> {
+map "<<LinkedList$Node>>" as _228d691985f93beaed469d085317435fb3665ef9 {
   next => null
   value =>
 }
-object "<U+0022>1<U+0022>" as _25f504355ec07b115120e557c385e256ddbe8e4e <<String>> {
+object "<<String>>" as _25f504355ec07b115120e557c385e256ddbe8e4e {
   "1"
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 : list
-_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602::head => _228d691985f93beaed469d085317435fb3665ef9 : head
-_228d691985f93beaed469d085317435fb3665ef9::value => _25f504355ec07b115120e557c385e256ddbe8e4e : value
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
+_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602::head => _228d691985f93beaed469d085317435fb3665ef9
+_228d691985f93beaed469d085317435fb3665ef9::value => _25f504355ec07b115120e557c385e256ddbe8e4e
 @enduml

--- a/src/object-diagram/logic/test-suites/linked-list/tests/2/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/2/object-diagram.json
@@ -2,40 +2,33 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602",
-      "type": "LinkedList",
-      "name": "LinkedList@9"
+      "type": "LinkedList"
     },
     {
       "id": "_228d691985f93beaed469d085317435fb3665ef9",
-      "type": "LinkedList$Node",
-      "name": "LinkedList$Node@17"
+      "type": "LinkedList$Node"
     },
     {
       "id": "_d2865ba5ee220622dea76e88fc2636f5678302a5",
-      "type": "LinkedList$Node",
-      "name": "LinkedList$Node@26"
+      "type": "LinkedList$Node"
     },
     {
       "id": "_aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d",
       "type": "String",
-      "name": "\"2\"",
       "value": "\"2\""
     },
     {
       "id": "_25f504355ec07b115120e557c385e256ddbe8e4e",
       "type": "String",
-      "name": "\"1\"",
       "value": "\"1\""
     }
   ],

--- a/src/object-diagram/logic/test-suites/linked-list/tests/2/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/2/writer/expected.gv
@@ -1,40 +1,40 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">list</td><td align="left" port="list"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList@9</b><br/><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
     <tr><td align="left">head</td><td align="left" port="head"></td></tr>
   </table>>]
   _228d691985f93beaed469d085317435fb3665ef9 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList$Node@17</b><br/><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
     <tr><td align="left">next</td><td align="left" port="next"></td></tr>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
   </table>>]
   _d2865ba5ee220622dea76e88fc2636f5678302a5 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList$Node@26</b><br/><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
     <tr><td align="left">next</td><td align="left" port="next">null</td></tr>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
   </table>>]
   _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"2"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"2"</td></tr>
   </table>>]
   _25f504355ec07b115120e557c385e256ddbe8e4e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"1"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"1"</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label="list"]
-  _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602:head -> _228d691985f93beaed469d085317435fb3665ef9 [label="head"]
-  _228d691985f93beaed469d085317435fb3665ef9:next -> _d2865ba5ee220622dea76e88fc2636f5678302a5 [label="next"]
-  _d2865ba5ee220622dea76e88fc2636f5678302a5:value -> _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d [label="value"]
-  _228d691985f93beaed469d085317435fb3665ef9:value -> _25f504355ec07b115120e557c385e256ddbe8e4e [label="value"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
+  _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602:head -> _228d691985f93beaed469d085317435fb3665ef9
+  _228d691985f93beaed469d085317435fb3665ef9:next -> _d2865ba5ee220622dea76e88fc2636f5678302a5
+  _d2865ba5ee220622dea76e88fc2636f5678302a5:value -> _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d
+  _228d691985f93beaed469d085317435fb3665ef9:value -> _25f504355ec07b115120e557c385e256ddbe8e4e
 }

--- a/src/object-diagram/logic/test-suites/linked-list/tests/2/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/2/writer/expected.puml
@@ -1,32 +1,32 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   args =>
   list =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-map "LinkedList@9" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 <<LinkedList>> {
+map "<<LinkedList>>" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 {
   head =>
 }
-map "LinkedList$Node@17" as _228d691985f93beaed469d085317435fb3665ef9 <<LinkedList$Node>> {
+map "<<LinkedList$Node>>" as _228d691985f93beaed469d085317435fb3665ef9 {
   next =>
   value =>
 }
-map "LinkedList$Node@26" as _d2865ba5ee220622dea76e88fc2636f5678302a5 <<LinkedList$Node>> {
+map "<<LinkedList$Node>>" as _d2865ba5ee220622dea76e88fc2636f5678302a5 {
   next => null
   value =>
 }
-object "<U+0022>2<U+0022>" as _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d <<String>> {
+object "<<String>>" as _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d {
   "2"
 }
-object "<U+0022>1<U+0022>" as _25f504355ec07b115120e557c385e256ddbe8e4e <<String>> {
+object "<<String>>" as _25f504355ec07b115120e557c385e256ddbe8e4e {
   "1"
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 : list
-_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602::head => _228d691985f93beaed469d085317435fb3665ef9 : head
-_228d691985f93beaed469d085317435fb3665ef9::next => _d2865ba5ee220622dea76e88fc2636f5678302a5 : next
-_d2865ba5ee220622dea76e88fc2636f5678302a5::value => _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d : value
-_228d691985f93beaed469d085317435fb3665ef9::value => _25f504355ec07b115120e557c385e256ddbe8e4e : value
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
+_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602::head => _228d691985f93beaed469d085317435fb3665ef9
+_228d691985f93beaed469d085317435fb3665ef9::next => _d2865ba5ee220622dea76e88fc2636f5678302a5
+_d2865ba5ee220622dea76e88fc2636f5678302a5::value => _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d
+_228d691985f93beaed469d085317435fb3665ef9::value => _25f504355ec07b115120e557c385e256ddbe8e4e
 @enduml

--- a/src/object-diagram/logic/test-suites/linked-list/tests/3/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/3/object-diagram.json
@@ -2,51 +2,42 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602",
-      "type": "LinkedList",
-      "name": "LinkedList@9"
+      "type": "LinkedList"
     },
     {
       "id": "_228d691985f93beaed469d085317435fb3665ef9",
-      "type": "LinkedList$Node",
-      "name": "LinkedList$Node@17"
+      "type": "LinkedList$Node"
     },
     {
       "id": "_d2865ba5ee220622dea76e88fc2636f5678302a5",
-      "type": "LinkedList$Node",
-      "name": "LinkedList$Node@26"
+      "type": "LinkedList$Node"
     },
     {
       "id": "_9216cc81275965426f13a25b0d4cc5251cf83d7c",
-      "type": "LinkedList$Node",
-      "name": "LinkedList$Node@28"
+      "type": "LinkedList$Node"
     },
     {
       "id": "_6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa",
       "type": "String",
-      "name": "\"3\"",
       "value": "\"3\""
     },
     {
       "id": "_aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d",
       "type": "String",
-      "name": "\"2\"",
       "value": "\"2\""
     },
     {
       "id": "_25f504355ec07b115120e557c385e256ddbe8e4e",
       "type": "String",
-      "name": "\"1\"",
       "value": "\"1\""
     }
   ],

--- a/src/object-diagram/logic/test-suites/linked-list/tests/3/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/3/writer/expected.gv
@@ -1,51 +1,51 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">list</td><td align="left" port="list"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList@9</b><br/><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList&gt;&gt;</i></td></th>
     <tr><td align="left">head</td><td align="left" port="head"></td></tr>
   </table>>]
   _228d691985f93beaed469d085317435fb3665ef9 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList$Node@17</b><br/><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
     <tr><td align="left">next</td><td align="left" port="next"></td></tr>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
   </table>>]
   _d2865ba5ee220622dea76e88fc2636f5678302a5 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList$Node@26</b><br/><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
     <tr><td align="left">next</td><td align="left" port="next"></td></tr>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
   </table>>]
   _9216cc81275965426f13a25b0d4cc5251cf83d7c [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>LinkedList$Node@28</b><br/><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;LinkedList$Node&gt;&gt;</i></td></th>
     <tr><td align="left">next</td><td align="left" port="next">null</td></tr>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
   </table>>]
   _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"3"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"3"</td></tr>
   </table>>]
   _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"2"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"2"</td></tr>
   </table>>]
   _25f504355ec07b115120e557c385e256ddbe8e4e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"1"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"1"</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 [label="list"]
-  _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602:head -> _228d691985f93beaed469d085317435fb3665ef9 [label="head"]
-  _228d691985f93beaed469d085317435fb3665ef9:next -> _d2865ba5ee220622dea76e88fc2636f5678302a5 [label="next"]
-  _d2865ba5ee220622dea76e88fc2636f5678302a5:next -> _9216cc81275965426f13a25b0d4cc5251cf83d7c [label="next"]
-  _9216cc81275965426f13a25b0d4cc5251cf83d7c:value -> _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa [label="value"]
-  _d2865ba5ee220622dea76e88fc2636f5678302a5:value -> _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d [label="value"]
-  _228d691985f93beaed469d085317435fb3665ef9:value -> _25f504355ec07b115120e557c385e256ddbe8e4e [label="value"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:list -> _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
+  _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602:head -> _228d691985f93beaed469d085317435fb3665ef9
+  _228d691985f93beaed469d085317435fb3665ef9:next -> _d2865ba5ee220622dea76e88fc2636f5678302a5
+  _d2865ba5ee220622dea76e88fc2636f5678302a5:next -> _9216cc81275965426f13a25b0d4cc5251cf83d7c
+  _9216cc81275965426f13a25b0d4cc5251cf83d7c:value -> _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa
+  _d2865ba5ee220622dea76e88fc2636f5678302a5:value -> _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d
+  _228d691985f93beaed469d085317435fb3665ef9:value -> _25f504355ec07b115120e557c385e256ddbe8e4e
 }

--- a/src/object-diagram/logic/test-suites/linked-list/tests/3/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/linked-list/tests/3/writer/expected.puml
@@ -1,41 +1,41 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   args =>
   list =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-map "LinkedList@9" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 <<LinkedList>> {
+map "<<LinkedList>>" as _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 {
   head =>
 }
-map "LinkedList$Node@17" as _228d691985f93beaed469d085317435fb3665ef9 <<LinkedList$Node>> {
+map "<<LinkedList$Node>>" as _228d691985f93beaed469d085317435fb3665ef9 {
   next =>
   value =>
 }
-map "LinkedList$Node@26" as _d2865ba5ee220622dea76e88fc2636f5678302a5 <<LinkedList$Node>> {
+map "<<LinkedList$Node>>" as _d2865ba5ee220622dea76e88fc2636f5678302a5 {
   next =>
   value =>
 }
-map "LinkedList$Node@28" as _9216cc81275965426f13a25b0d4cc5251cf83d7c <<LinkedList$Node>> {
+map "<<LinkedList$Node>>" as _9216cc81275965426f13a25b0d4cc5251cf83d7c {
   next => null
   value =>
 }
-object "<U+0022>3<U+0022>" as _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa <<String>> {
+object "<<String>>" as _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa {
   "3"
 }
-object "<U+0022>2<U+0022>" as _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d <<String>> {
+object "<<String>>" as _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d {
   "2"
 }
-object "<U+0022>1<U+0022>" as _25f504355ec07b115120e557c385e256ddbe8e4e <<String>> {
+object "<<String>>" as _25f504355ec07b115120e557c385e256ddbe8e4e {
   "1"
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602 : list
-_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602::head => _228d691985f93beaed469d085317435fb3665ef9 : head
-_228d691985f93beaed469d085317435fb3665ef9::next => _d2865ba5ee220622dea76e88fc2636f5678302a5 : next
-_d2865ba5ee220622dea76e88fc2636f5678302a5::next => _9216cc81275965426f13a25b0d4cc5251cf83d7c : next
-_9216cc81275965426f13a25b0d4cc5251cf83d7c::value => _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa : value
-_d2865ba5ee220622dea76e88fc2636f5678302a5::value => _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d : value
-_228d691985f93beaed469d085317435fb3665ef9::value => _25f504355ec07b115120e557c385e256ddbe8e4e : value
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::list => _7f72fde5bcfbd3fa5f2426e64a749e253c7dc602
+_7f72fde5bcfbd3fa5f2426e64a749e253c7dc602::head => _228d691985f93beaed469d085317435fb3665ef9
+_228d691985f93beaed469d085317435fb3665ef9::next => _d2865ba5ee220622dea76e88fc2636f5678302a5
+_d2865ba5ee220622dea76e88fc2636f5678302a5::next => _9216cc81275965426f13a25b0d4cc5251cf83d7c
+_9216cc81275965426f13a25b0d4cc5251cf83d7c::value => _6c8ee4d6b87c98cd376adf5b3a8536fbe38a8afa
+_d2865ba5ee220622dea76e88fc2636f5678302a5::value => _aa72d35e21c1d6132dbb8e75f8fbc7117c4f423d
+_228d691985f93beaed469d085317435fb3665ef9::value => _25f504355ec07b115120e557c385e256ddbe8e4e
 @enduml

--- a/src/object-diagram/logic/test-suites/miscellaneous/tests/enum/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/miscellaneous/tests/enum/object-diagram.json
@@ -2,46 +2,38 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_782d99bf989d0a8059bfc0b89707b5fecd44189a",
-      "type": "Point",
-      "name": "Point@9 \"x: 1 y: 1\""
+      "type": "Point"
     },
     {
       "id": "_a4085fe64a34efdca9c495374ced14d982a9fcf0",
-      "type": "Point",
-      "name": "Point@10 \"x: 5 y: 7\""
+      "type": "Point"
     },
     {
       "id": "_c782cb251d54e777f73ba090318ea4549ea0154c",
-      "type": "Color",
-      "name": "Color@11 \"BLUE\""
+      "type": "Color"
     },
     {
       "id": "_ddc022e583fa6f700df84118a557f6ee593d0896",
       "type": "String",
-      "name": "\"#0000FF\"",
       "value": "\"#0000FF\""
     },
     {
       "id": "_68f417e07413646bc6802be73fa896ef65e71986",
       "type": "String",
-      "name": "\"BLUE\"",
       "value": "\"BLUE\""
     },
     {
       "id": "_2fc96ff8cf245465ff831587cf4c032a1fee1ecb",
       "type": "String",
-      "name": "\"blue\"",
       "value": "\"blue\""
     }
   ],

--- a/src/object-diagram/logic/test-suites/miscellaneous/tests/enum/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/miscellaneous/tests/enum/writer/expected.gv
@@ -1,7 +1,7 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">borderWidth</td><td align="left" port="borderWidth">5 (int)</td></tr>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">topLeft</td><td align="left" port="topLeft"></td></tr>
@@ -10,44 +10,44 @@ digraph ObjectDiagram {
     <tr><td align="left">background</td><td align="left" port="background"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _782d99bf989d0a8059bfc0b89707b5fecd44189a [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Point@9 "x: 1 y: 1"</b><br/><i>&lt;&lt;Point&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Point&gt;&gt;</i></td></th>
     <tr><td align="left">x</td><td align="left" port="x">1 (int)</td></tr>
     <tr><td align="left">y</td><td align="left" port="y">1 (int)</td></tr>
   </table>>]
   _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Point@10 "x: 5 y: 7"</b><br/><i>&lt;&lt;Point&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Point&gt;&gt;</i></td></th>
     <tr><td align="left">x</td><td align="left" port="x">5 (int)</td></tr>
     <tr><td align="left">y</td><td align="left" port="y">7 (int)</td></tr>
   </table>>]
   _c782cb251d54e777f73ba090318ea4549ea0154c [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Color@11 "BLUE"</b><br/><i>&lt;&lt;Color&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Color&gt;&gt;</i></td></th>
     <tr><td align="left">ordinal</td><td align="left" port="ordinal">2 (int)</td></tr>
     <tr><td align="left">hexValue</td><td align="left" port="hexValue"></td></tr>
     <tr><td align="left">name</td><td align="left" port="name"></td></tr>
     <tr><td align="left">textValue</td><td align="left" port="textValue"></td></tr>
   </table>>]
   _ddc022e583fa6f700df84118a557f6ee593d0896 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"#0000FF"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"#0000FF"</td></tr>
   </table>>]
   _68f417e07413646bc6802be73fa896ef65e71986 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"BLUE"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"BLUE"</td></tr>
   </table>>]
   _2fc96ff8cf245465ff831587cf4c032a1fee1ecb [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"blue"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"blue"</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:topLeft -> _782d99bf989d0a8059bfc0b89707b5fecd44189a [label="topLeft"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:topLeftCopy -> _782d99bf989d0a8059bfc0b89707b5fecd44189a [label="topLeftCopy"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:bottomRight -> _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label="bottomRight"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:background -> _c782cb251d54e777f73ba090318ea4549ea0154c [label="background"]
-  _c782cb251d54e777f73ba090318ea4549ea0154c:hexValue -> _ddc022e583fa6f700df84118a557f6ee593d0896 [label="hexValue"]
-  _c782cb251d54e777f73ba090318ea4549ea0154c:name -> _68f417e07413646bc6802be73fa896ef65e71986 [label="name"]
-  _c782cb251d54e777f73ba090318ea4549ea0154c:textValue -> _2fc96ff8cf245465ff831587cf4c032a1fee1ecb [label="textValue"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:topLeft -> _782d99bf989d0a8059bfc0b89707b5fecd44189a
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:topLeftCopy -> _782d99bf989d0a8059bfc0b89707b5fecd44189a
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:bottomRight -> _a4085fe64a34efdca9c495374ced14d982a9fcf0
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:background -> _c782cb251d54e777f73ba090318ea4549ea0154c
+  _c782cb251d54e777f73ba090318ea4549ea0154c:hexValue -> _ddc022e583fa6f700df84118a557f6ee593d0896
+  _c782cb251d54e777f73ba090318ea4549ea0154c:name -> _68f417e07413646bc6802be73fa896ef65e71986
+  _c782cb251d54e777f73ba090318ea4549ea0154c:textValue -> _2fc96ff8cf245465ff831587cf4c032a1fee1ecb
 }

--- a/src/object-diagram/logic/test-suites/miscellaneous/tests/enum/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/miscellaneous/tests/enum/writer/expected.puml
@@ -1,5 +1,5 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   borderWidth => 5 (int)
   args =>
   topLeft =>
@@ -7,38 +7,38 @@ map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>>
   bottomRight =>
   background =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-map "Point@9 <U+0022>x: 1 y: 1<U+0022>" as _782d99bf989d0a8059bfc0b89707b5fecd44189a <<Point>> {
+map "<<Point>>" as _782d99bf989d0a8059bfc0b89707b5fecd44189a {
   x => 1 (int)
   y => 1 (int)
 }
-map "Point@10 <U+0022>x: 5 y: 7<U+0022>" as _a4085fe64a34efdca9c495374ced14d982a9fcf0 <<Point>> {
+map "<<Point>>" as _a4085fe64a34efdca9c495374ced14d982a9fcf0 {
   x => 5 (int)
   y => 7 (int)
 }
-map "Color@11 <U+0022>BLUE<U+0022>" as _c782cb251d54e777f73ba090318ea4549ea0154c <<Color>> {
+map "<<Color>>" as _c782cb251d54e777f73ba090318ea4549ea0154c {
   ordinal => 2 (int)
   hexValue =>
   name =>
   textValue =>
 }
-object "<U+0022>#0000FF<U+0022>" as _ddc022e583fa6f700df84118a557f6ee593d0896 <<String>> {
+object "<<String>>" as _ddc022e583fa6f700df84118a557f6ee593d0896 {
   "#0000FF"
 }
-object "<U+0022>BLUE<U+0022>" as _68f417e07413646bc6802be73fa896ef65e71986 <<String>> {
+object "<<String>>" as _68f417e07413646bc6802be73fa896ef65e71986 {
   "BLUE"
 }
-object "<U+0022>blue<U+0022>" as _2fc96ff8cf245465ff831587cf4c032a1fee1ecb <<String>> {
+object "<<String>>" as _2fc96ff8cf245465ff831587cf4c032a1fee1ecb {
   "blue"
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::topLeft => _782d99bf989d0a8059bfc0b89707b5fecd44189a : topLeft
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::topLeftCopy => _782d99bf989d0a8059bfc0b89707b5fecd44189a : topLeftCopy
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::bottomRight => _a4085fe64a34efdca9c495374ced14d982a9fcf0 : bottomRight
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::background => _c782cb251d54e777f73ba090318ea4549ea0154c : background
-_c782cb251d54e777f73ba090318ea4549ea0154c::hexValue => _ddc022e583fa6f700df84118a557f6ee593d0896 : hexValue
-_c782cb251d54e777f73ba090318ea4549ea0154c::name => _68f417e07413646bc6802be73fa896ef65e71986 : name
-_c782cb251d54e777f73ba090318ea4549ea0154c::textValue => _2fc96ff8cf245465ff831587cf4c032a1fee1ecb : textValue
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::topLeft => _782d99bf989d0a8059bfc0b89707b5fecd44189a
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::topLeftCopy => _782d99bf989d0a8059bfc0b89707b5fecd44189a
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::bottomRight => _a4085fe64a34efdca9c495374ced14d982a9fcf0
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::background => _c782cb251d54e777f73ba090318ea4549ea0154c
+_c782cb251d54e777f73ba090318ea4549ea0154c::hexValue => _ddc022e583fa6f700df84118a557f6ee593d0896
+_c782cb251d54e777f73ba090318ea4549ea0154c::name => _68f417e07413646bc6802be73fa896ef65e71986
+_c782cb251d54e777f73ba090318ea4549ea0154c::textValue => _2fc96ff8cf245465ff831587cf4c032a1fee1ecb
 @enduml

--- a/src/object-diagram/logic/test-suites/miscellaneous/tests/full/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/miscellaneous/tests/full/object-diagram.json
@@ -2,141 +2,116 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_1b1d14e75647f191269ac449d87d9ac12506b865",
-      "type": "Point",
-      "name": "Point@9 \"x: 42 y: 1\""
+      "type": "Point"
     },
     {
       "id": "_a4085fe64a34efdca9c495374ced14d982a9fcf0",
-      "type": "Point",
-      "name": "Point@10 \"x: 5 y: 7\""
+      "type": "Point"
     },
     {
       "id": "_c782cb251d54e777f73ba090318ea4549ea0154c",
-      "type": "Color",
-      "name": "Color@11 \"BLUE\""
+      "type": "Color"
     },
     {
       "id": "_ddc022e583fa6f700df84118a557f6ee593d0896",
       "type": "String",
-      "name": "\"#0000FF\"",
       "value": "\"#0000FF\""
     },
     {
       "id": "_68f417e07413646bc6802be73fa896ef65e71986",
       "type": "String",
-      "name": "\"BLUE\"",
       "value": "\"BLUE\""
     },
     {
       "id": "_2fc96ff8cf245465ff831587cf4c032a1fee1ecb",
       "type": "String",
-      "name": "\"blue\"",
       "value": "\"blue\""
     },
     {
       "id": "_83b1db9c519c2b87f16cd319822b17b3c6a62a8e",
-      "type": "Color",
-      "name": "Color@37 \"GREEN\""
+      "type": "Color"
     },
     {
       "id": "_f38dba1e51caf683679520a6946afc772ac2222d",
       "type": "String",
-      "name": "\"#00FF00\"",
       "value": "\"#00FF00\""
     },
     {
       "id": "_ed9882efaf59d7dfde3338f3304ac8f964ed8375",
       "type": "String",
-      "name": "\"GREEN\"",
       "value": "\"GREEN\""
     },
     {
       "id": "_4593e280546f904a7f1a2b3c5cfa43d8ae500f53",
       "type": "String",
-      "name": "\"green\"",
       "value": "\"green\""
     },
     {
       "id": "_33682ad97510072b61183de7a4bb48da0e39b0b1",
       "type": "String",
-      "name": "\"topLeft\"",
       "value": "\"topLeft\""
     },
     {
       "id": "_e91898f089a0f9e253c468c6d8d606f38cf85329",
-      "type": "Rectangle",
-      "name": "Rectangle@39 \"topLeft\""
+      "type": "Rectangle"
     },
     {
       "id": "_86d2b65f32348774927a79d7a31769d7e10f45e3",
-      "type": "HashMap",
-      "name": "HashMap@40 size=3"
+      "type": "HashMap"
     },
     {
       "id": "_a21cb739419a4eaab8ba844909b45dd76458437f",
-      "type": "HashMap$Node",
-      "name": "HashMap$Node@68 \"top left\":null"
+      "type": "HashMap$Node"
     },
     {
       "id": "_cd6760fb5af30e8ebf4ff44f153961f212af9bb5",
       "type": "String",
-      "name": "\"top left\"",
       "value": "\"top left\""
     },
     {
       "id": "_1163868589bb43fc94f11464b480fbb3e9138123",
-      "type": "HashMap$Node",
-      "name": "HashMap$Node@69 \"middle\":null"
+      "type": "HashMap$Node"
     },
     {
       "id": "_34de41e50bb069b8e9e78b1b7731121eb4debf9c",
       "type": "String",
-      "name": "\"middle\"",
       "value": "\"middle\""
     },
     {
       "id": "_687cda35abd48b9a7e14c54e9ef62d1f9cc080a7",
-      "type": "HashMap$Node",
-      "name": "HashMap$Node@70 \"bottom right\":\"x: 5 y: 7\""
+      "type": "HashMap$Node"
     },
     {
       "id": "_9ec248d870dc55767f1de0ba3545ed57f767a43c",
       "type": "String",
-      "name": "\"bottom right\"",
       "value": "\"bottom right\""
     },
     {
       "id": "_26cb8f97b39839eb7ae52c25f2f8d102403660b5",
       "type": "int[]",
-      "name": "int[58]@41",
       "value": "[2,3,5,7,11,13,17,19,23,29,…]"
     },
     {
       "id": "_71d4b85b1d4247e6d2f27d76c2384fefeec170bd",
       "type": "String[]",
-      "name": "String[2]@42",
       "value": "[\"one\",\"two\"]"
     },
     {
       "id": "_d2d6627a35a13caa54370564ee9914486bf006b6",
-      "type": "Point[]",
-      "name": "Point[3]@43"
+      "type": "Point[]"
     },
     {
       "id": "_19700cd8fd1b87bef6d2046533a6afbb10c87d0a",
-      "type": "Point",
-      "name": "Point@80 \"x: 1337 y: 7331\""
+      "type": "Point"
     }
   ],
   "fields": [

--- a/src/object-diagram/logic/test-suites/miscellaneous/tests/full/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/miscellaneous/tests/full/writer/expected.gv
@@ -1,7 +1,7 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">borderWidth</td><td align="left" port="borderWidth">3 (int)</td></tr>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">topLeftCopy</td><td align="left" port="topLeftCopy"></td></tr>
@@ -16,63 +16,63 @@ digraph ObjectDiagram {
     <tr><td align="left">points</td><td align="left" port="points"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _1b1d14e75647f191269ac449d87d9ac12506b865 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Point@9 "x: 42 y: 1"</b><br/><i>&lt;&lt;Point&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Point&gt;&gt;</i></td></th>
     <tr><td align="left">x</td><td align="left" port="x">42 (int)</td></tr>
     <tr><td align="left">y</td><td align="left" port="y">1 (int)</td></tr>
   </table>>]
   _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Point@10 "x: 5 y: 7"</b><br/><i>&lt;&lt;Point&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Point&gt;&gt;</i></td></th>
     <tr><td align="left">x</td><td align="left" port="x">5 (int)</td></tr>
     <tr><td align="left">y</td><td align="left" port="y">7 (int)</td></tr>
   </table>>]
   _c782cb251d54e777f73ba090318ea4549ea0154c [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Color@11 "BLUE"</b><br/><i>&lt;&lt;Color&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Color&gt;&gt;</i></td></th>
     <tr><td align="left">ordinal</td><td align="left" port="ordinal">2 (int)</td></tr>
     <tr><td align="left">hexValue</td><td align="left" port="hexValue"></td></tr>
     <tr><td align="left">name</td><td align="left" port="name"></td></tr>
     <tr><td align="left">textValue</td><td align="left" port="textValue"></td></tr>
   </table>>]
   _ddc022e583fa6f700df84118a557f6ee593d0896 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"#0000FF"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"#0000FF"</td></tr>
   </table>>]
   _68f417e07413646bc6802be73fa896ef65e71986 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"BLUE"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"BLUE"</td></tr>
   </table>>]
   _2fc96ff8cf245465ff831587cf4c032a1fee1ecb [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"blue"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"blue"</td></tr>
   </table>>]
   _83b1db9c519c2b87f16cd319822b17b3c6a62a8e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Color@37 "GREEN"</b><br/><i>&lt;&lt;Color&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Color&gt;&gt;</i></td></th>
     <tr><td align="left">ordinal</td><td align="left" port="ordinal">1 (int)</td></tr>
     <tr><td align="left">hexValue</td><td align="left" port="hexValue"></td></tr>
     <tr><td align="left">name</td><td align="left" port="name"></td></tr>
     <tr><td align="left">textValue</td><td align="left" port="textValue"></td></tr>
   </table>>]
   _f38dba1e51caf683679520a6946afc772ac2222d [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"#00FF00"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"#00FF00"</td></tr>
   </table>>]
   _ed9882efaf59d7dfde3338f3304ac8f964ed8375 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"GREEN"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"GREEN"</td></tr>
   </table>>]
   _4593e280546f904a7f1a2b3c5cfa43d8ae500f53 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"green"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"green"</td></tr>
   </table>>]
   _33682ad97510072b61183de7a4bb48da0e39b0b1 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"topLeft"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"topLeft"</td></tr>
   </table>>]
   _e91898f089a0f9e253c468c6d8d606f38cf85329 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Rectangle@39 "topLeft"</b><br/><i>&lt;&lt;Rectangle&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Rectangle&gt;&gt;</i></td></th>
     <tr><td align="left">borderWidth</td><td align="left" port="borderWidth">3 (int)</td></tr>
     <tr><td align="left">topLeft</td><td align="left" port="topLeft">null</td></tr>
     <tr><td align="left">bottomRight</td><td align="left" port="bottomRight"></td></tr>
@@ -81,85 +81,85 @@ digraph ObjectDiagram {
     <tr><td align="left">text</td><td align="left" port="text"></td></tr>
   </table>>]
   _86d2b65f32348774927a79d7a31769d7e10f45e3 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>HashMap@40 size=3</b><br/><i>&lt;&lt;HashMap&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;HashMap&gt;&gt;</i></td></th>
     <tr><td align="left">0</td><td align="left" port="0"></td></tr>
     <tr><td align="left">1</td><td align="left" port="1"></td></tr>
     <tr><td align="left">2</td><td align="left" port="2"></td></tr>
   </table>>]
   _a21cb739419a4eaab8ba844909b45dd76458437f [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>HashMap$Node@68 "top left":null</b><br/><i>&lt;&lt;HashMap$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;HashMap$Node&gt;&gt;</i></td></th>
     <tr><td align="left">value</td><td align="left" port="value">null</td></tr>
     <tr><td align="left">key</td><td align="left" port="key"></td></tr>
   </table>>]
   _cd6760fb5af30e8ebf4ff44f153961f212af9bb5 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"top left"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"top left"</td></tr>
   </table>>]
   _1163868589bb43fc94f11464b480fbb3e9138123 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>HashMap$Node@69 "middle":null</b><br/><i>&lt;&lt;HashMap$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;HashMap$Node&gt;&gt;</i></td></th>
     <tr><td align="left">value</td><td align="left" port="value">null</td></tr>
     <tr><td align="left">key</td><td align="left" port="key"></td></tr>
   </table>>]
   _34de41e50bb069b8e9e78b1b7731121eb4debf9c [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"middle"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"middle"</td></tr>
   </table>>]
   _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>HashMap$Node@70 "bottom right":"x: 5 y: 7"</b><br/><i>&lt;&lt;HashMap$Node&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;HashMap$Node&gt;&gt;</i></td></th>
     <tr><td align="left">value</td><td align="left" port="value"></td></tr>
     <tr><td align="left">key</td><td align="left" port="key"></td></tr>
   </table>>]
   _9ec248d870dc55767f1de0ba3545ed57f767a43c [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>"bottom right"</b><br/><i>&lt;&lt;String&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String&gt;&gt;</i></td></th>
     <tr><td colspan="2">"bottom right"</td></tr>
   </table>>]
   _26cb8f97b39839eb7ae52c25f2f8d102403660b5 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>int[58]@41</b><br/><i>&lt;&lt;int[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;int[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[2,3,5,7,11,13,17,19,23,29,…]</td></tr>
   </table>>]
   _71d4b85b1d4247e6d2f27d76c2384fefeec170bd [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[2]@42</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">["one","two"]</td></tr>
   </table>>]
   _d2d6627a35a13caa54370564ee9914486bf006b6 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Point[3]@43</b><br/><i>&lt;&lt;Point[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Point[]&gt;&gt;</i></td></th>
     <tr><td align="left">2</td><td align="left" port="2">null</td></tr>
     <tr><td align="left">1</td><td align="left" port="1"></td></tr>
     <tr><td align="left">0</td><td align="left" port="0"></td></tr>
   </table>>]
   _19700cd8fd1b87bef6d2046533a6afbb10c87d0a [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>Point@80 "x: 1337 y: 7331"</b><br/><i>&lt;&lt;Point&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;Point&gt;&gt;</i></td></th>
     <tr><td align="left">x</td><td align="left" port="x">1337 (int)</td></tr>
     <tr><td align="left">y</td><td align="left" port="y">7331 (int)</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:topLeftCopy -> _1b1d14e75647f191269ac449d87d9ac12506b865 [label="topLeftCopy"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:bottomRight -> _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label="bottomRight"]
-  _e91898f089a0f9e253c468c6d8d606f38cf85329:bottomRight -> _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label="bottomRight"]
-  _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7:value -> _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label="value"]
-  _d2d6627a35a13caa54370564ee9914486bf006b6:1 -> _a4085fe64a34efdca9c495374ced14d982a9fcf0 [label="1"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:background -> _c782cb251d54e777f73ba090318ea4549ea0154c [label="background"]
-  _e91898f089a0f9e253c468c6d8d606f38cf85329:backgroundColor -> _c782cb251d54e777f73ba090318ea4549ea0154c [label="backgroundColor"]
-  _c782cb251d54e777f73ba090318ea4549ea0154c:hexValue -> _ddc022e583fa6f700df84118a557f6ee593d0896 [label="hexValue"]
-  _c782cb251d54e777f73ba090318ea4549ea0154c:name -> _68f417e07413646bc6802be73fa896ef65e71986 [label="name"]
-  _c782cb251d54e777f73ba090318ea4549ea0154c:textValue -> _2fc96ff8cf245465ff831587cf4c032a1fee1ecb [label="textValue"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:border -> _83b1db9c519c2b87f16cd319822b17b3c6a62a8e [label="border"]
-  _e91898f089a0f9e253c468c6d8d606f38cf85329:borderColor -> _83b1db9c519c2b87f16cd319822b17b3c6a62a8e [label="borderColor"]
-  _83b1db9c519c2b87f16cd319822b17b3c6a62a8e:hexValue -> _f38dba1e51caf683679520a6946afc772ac2222d [label="hexValue"]
-  _83b1db9c519c2b87f16cd319822b17b3c6a62a8e:name -> _ed9882efaf59d7dfde3338f3304ac8f964ed8375 [label="name"]
-  _83b1db9c519c2b87f16cd319822b17b3c6a62a8e:textValue -> _4593e280546f904a7f1a2b3c5cfa43d8ae500f53 [label="textValue"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:text -> _33682ad97510072b61183de7a4bb48da0e39b0b1 [label="text"]
-  _e91898f089a0f9e253c468c6d8d606f38cf85329:text -> _33682ad97510072b61183de7a4bb48da0e39b0b1 [label="text"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:rect -> _e91898f089a0f9e253c468c6d8d606f38cf85329 [label="rect"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:map -> _86d2b65f32348774927a79d7a31769d7e10f45e3 [label="map"]
-  _86d2b65f32348774927a79d7a31769d7e10f45e3:0 -> _a21cb739419a4eaab8ba844909b45dd76458437f [label="0"]
-  _a21cb739419a4eaab8ba844909b45dd76458437f:key -> _cd6760fb5af30e8ebf4ff44f153961f212af9bb5 [label="key"]
-  _86d2b65f32348774927a79d7a31769d7e10f45e3:1 -> _1163868589bb43fc94f11464b480fbb3e9138123 [label="1"]
-  _1163868589bb43fc94f11464b480fbb3e9138123:key -> _34de41e50bb069b8e9e78b1b7731121eb4debf9c [label="key"]
-  _86d2b65f32348774927a79d7a31769d7e10f45e3:2 -> _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7 [label="2"]
-  _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7:key -> _9ec248d870dc55767f1de0ba3545ed57f767a43c [label="key"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:intArray -> _26cb8f97b39839eb7ae52c25f2f8d102403660b5 [label="intArray"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:stringArray -> _71d4b85b1d4247e6d2f27d76c2384fefeec170bd [label="stringArray"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:points -> _d2d6627a35a13caa54370564ee9914486bf006b6 [label="points"]
-  _d2d6627a35a13caa54370564ee9914486bf006b6:0 -> _19700cd8fd1b87bef6d2046533a6afbb10c87d0a [label="0"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:topLeftCopy -> _1b1d14e75647f191269ac449d87d9ac12506b865
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:bottomRight -> _a4085fe64a34efdca9c495374ced14d982a9fcf0
+  _e91898f089a0f9e253c468c6d8d606f38cf85329:bottomRight -> _a4085fe64a34efdca9c495374ced14d982a9fcf0
+  _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7:value -> _a4085fe64a34efdca9c495374ced14d982a9fcf0
+  _d2d6627a35a13caa54370564ee9914486bf006b6:1 -> _a4085fe64a34efdca9c495374ced14d982a9fcf0
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:background -> _c782cb251d54e777f73ba090318ea4549ea0154c
+  _e91898f089a0f9e253c468c6d8d606f38cf85329:backgroundColor -> _c782cb251d54e777f73ba090318ea4549ea0154c
+  _c782cb251d54e777f73ba090318ea4549ea0154c:hexValue -> _ddc022e583fa6f700df84118a557f6ee593d0896
+  _c782cb251d54e777f73ba090318ea4549ea0154c:name -> _68f417e07413646bc6802be73fa896ef65e71986
+  _c782cb251d54e777f73ba090318ea4549ea0154c:textValue -> _2fc96ff8cf245465ff831587cf4c032a1fee1ecb
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:border -> _83b1db9c519c2b87f16cd319822b17b3c6a62a8e
+  _e91898f089a0f9e253c468c6d8d606f38cf85329:borderColor -> _83b1db9c519c2b87f16cd319822b17b3c6a62a8e
+  _83b1db9c519c2b87f16cd319822b17b3c6a62a8e:hexValue -> _f38dba1e51caf683679520a6946afc772ac2222d
+  _83b1db9c519c2b87f16cd319822b17b3c6a62a8e:name -> _ed9882efaf59d7dfde3338f3304ac8f964ed8375
+  _83b1db9c519c2b87f16cd319822b17b3c6a62a8e:textValue -> _4593e280546f904a7f1a2b3c5cfa43d8ae500f53
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:text -> _33682ad97510072b61183de7a4bb48da0e39b0b1
+  _e91898f089a0f9e253c468c6d8d606f38cf85329:text -> _33682ad97510072b61183de7a4bb48da0e39b0b1
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:rect -> _e91898f089a0f9e253c468c6d8d606f38cf85329
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:map -> _86d2b65f32348774927a79d7a31769d7e10f45e3
+  _86d2b65f32348774927a79d7a31769d7e10f45e3:0 -> _a21cb739419a4eaab8ba844909b45dd76458437f
+  _a21cb739419a4eaab8ba844909b45dd76458437f:key -> _cd6760fb5af30e8ebf4ff44f153961f212af9bb5
+  _86d2b65f32348774927a79d7a31769d7e10f45e3:1 -> _1163868589bb43fc94f11464b480fbb3e9138123
+  _1163868589bb43fc94f11464b480fbb3e9138123:key -> _34de41e50bb069b8e9e78b1b7731121eb4debf9c
+  _86d2b65f32348774927a79d7a31769d7e10f45e3:2 -> _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7
+  _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7:key -> _9ec248d870dc55767f1de0ba3545ed57f767a43c
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:intArray -> _26cb8f97b39839eb7ae52c25f2f8d102403660b5
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:stringArray -> _71d4b85b1d4247e6d2f27d76c2384fefeec170bd
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:points -> _d2d6627a35a13caa54370564ee9914486bf006b6
+  _d2d6627a35a13caa54370564ee9914486bf006b6:0 -> _19700cd8fd1b87bef6d2046533a6afbb10c87d0a
 }

--- a/src/object-diagram/logic/test-suites/miscellaneous/tests/full/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/miscellaneous/tests/full/writer/expected.puml
@@ -1,5 +1,5 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   borderWidth => 3 (int)
   args =>
   topLeftCopy =>
@@ -13,51 +13,51 @@ map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>>
   stringArray =>
   points =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-map "Point@9 <U+0022>x: 42 y: 1<U+0022>" as _1b1d14e75647f191269ac449d87d9ac12506b865 <<Point>> {
+map "<<Point>>" as _1b1d14e75647f191269ac449d87d9ac12506b865 {
   x => 42 (int)
   y => 1 (int)
 }
-map "Point@10 <U+0022>x: 5 y: 7<U+0022>" as _a4085fe64a34efdca9c495374ced14d982a9fcf0 <<Point>> {
+map "<<Point>>" as _a4085fe64a34efdca9c495374ced14d982a9fcf0 {
   x => 5 (int)
   y => 7 (int)
 }
-map "Color@11 <U+0022>BLUE<U+0022>" as _c782cb251d54e777f73ba090318ea4549ea0154c <<Color>> {
+map "<<Color>>" as _c782cb251d54e777f73ba090318ea4549ea0154c {
   ordinal => 2 (int)
   hexValue =>
   name =>
   textValue =>
 }
-object "<U+0022>#0000FF<U+0022>" as _ddc022e583fa6f700df84118a557f6ee593d0896 <<String>> {
+object "<<String>>" as _ddc022e583fa6f700df84118a557f6ee593d0896 {
   "#0000FF"
 }
-object "<U+0022>BLUE<U+0022>" as _68f417e07413646bc6802be73fa896ef65e71986 <<String>> {
+object "<<String>>" as _68f417e07413646bc6802be73fa896ef65e71986 {
   "BLUE"
 }
-object "<U+0022>blue<U+0022>" as _2fc96ff8cf245465ff831587cf4c032a1fee1ecb <<String>> {
+object "<<String>>" as _2fc96ff8cf245465ff831587cf4c032a1fee1ecb {
   "blue"
 }
-map "Color@37 <U+0022>GREEN<U+0022>" as _83b1db9c519c2b87f16cd319822b17b3c6a62a8e <<Color>> {
+map "<<Color>>" as _83b1db9c519c2b87f16cd319822b17b3c6a62a8e {
   ordinal => 1 (int)
   hexValue =>
   name =>
   textValue =>
 }
-object "<U+0022>#00FF00<U+0022>" as _f38dba1e51caf683679520a6946afc772ac2222d <<String>> {
+object "<<String>>" as _f38dba1e51caf683679520a6946afc772ac2222d {
   "#00FF00"
 }
-object "<U+0022>GREEN<U+0022>" as _ed9882efaf59d7dfde3338f3304ac8f964ed8375 <<String>> {
+object "<<String>>" as _ed9882efaf59d7dfde3338f3304ac8f964ed8375 {
   "GREEN"
 }
-object "<U+0022>green<U+0022>" as _4593e280546f904a7f1a2b3c5cfa43d8ae500f53 <<String>> {
+object "<<String>>" as _4593e280546f904a7f1a2b3c5cfa43d8ae500f53 {
   "green"
 }
-object "<U+0022>topLeft<U+0022>" as _33682ad97510072b61183de7a4bb48da0e39b0b1 <<String>> {
+object "<<String>>" as _33682ad97510072b61183de7a4bb48da0e39b0b1 {
   "topLeft"
 }
-map "Rectangle@39 <U+0022>topLeft<U+0022>" as _e91898f089a0f9e253c468c6d8d606f38cf85329 <<Rectangle>> {
+map "<<Rectangle>>" as _e91898f089a0f9e253c468c6d8d606f38cf85329 {
   borderWidth => 3 (int)
   topLeft => null
   bottomRight =>
@@ -65,75 +65,75 @@ map "Rectangle@39 <U+0022>topLeft<U+0022>" as _e91898f089a0f9e253c468c6d8d606f38
   borderColor =>
   text =>
 }
-map "HashMap@40 size=3" as _86d2b65f32348774927a79d7a31769d7e10f45e3 <<HashMap>> {
+map "<<HashMap>>" as _86d2b65f32348774927a79d7a31769d7e10f45e3 {
   0 =>
   1 =>
   2 =>
 }
-map "HashMap$Node@68 <U+0022>top left<U+0022>:null" as _a21cb739419a4eaab8ba844909b45dd76458437f <<HashMap$Node>> {
+map "<<HashMap$Node>>" as _a21cb739419a4eaab8ba844909b45dd76458437f {
   value => null
   key =>
 }
-object "<U+0022>top left<U+0022>" as _cd6760fb5af30e8ebf4ff44f153961f212af9bb5 <<String>> {
+object "<<String>>" as _cd6760fb5af30e8ebf4ff44f153961f212af9bb5 {
   "top left"
 }
-map "HashMap$Node@69 <U+0022>middle<U+0022>:null" as _1163868589bb43fc94f11464b480fbb3e9138123 <<HashMap$Node>> {
+map "<<HashMap$Node>>" as _1163868589bb43fc94f11464b480fbb3e9138123 {
   value => null
   key =>
 }
-object "<U+0022>middle<U+0022>" as _34de41e50bb069b8e9e78b1b7731121eb4debf9c <<String>> {
+object "<<String>>" as _34de41e50bb069b8e9e78b1b7731121eb4debf9c {
   "middle"
 }
-map "HashMap$Node@70 <U+0022>bottom right<U+0022>:<U+0022>x: 5 y: 7<U+0022>" as _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7 <<HashMap$Node>> {
+map "<<HashMap$Node>>" as _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7 {
   value =>
   key =>
 }
-object "<U+0022>bottom right<U+0022>" as _9ec248d870dc55767f1de0ba3545ed57f767a43c <<String>> {
+object "<<String>>" as _9ec248d870dc55767f1de0ba3545ed57f767a43c {
   "bottom right"
 }
-object "int[58]@41" as _26cb8f97b39839eb7ae52c25f2f8d102403660b5 <<int[]>> {
+object "<<int[]>>" as _26cb8f97b39839eb7ae52c25f2f8d102403660b5 {
   [2,3,5,7,11,13,17,19,23,29,…]
 }
-object "String[2]@42" as _71d4b85b1d4247e6d2f27d76c2384fefeec170bd <<String[]>> {
+object "<<String[]>>" as _71d4b85b1d4247e6d2f27d76c2384fefeec170bd {
   ["one","two"]
 }
-map "Point[3]@43" as _d2d6627a35a13caa54370564ee9914486bf006b6 <<Point[]>> {
+map "<<Point[]>>" as _d2d6627a35a13caa54370564ee9914486bf006b6 {
   2 => null
   1 =>
   0 =>
 }
-map "Point@80 <U+0022>x: 1337 y: 7331<U+0022>" as _19700cd8fd1b87bef6d2046533a6afbb10c87d0a <<Point>> {
+map "<<Point>>" as _19700cd8fd1b87bef6d2046533a6afbb10c87d0a {
   x => 1337 (int)
   y => 7331 (int)
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::topLeftCopy => _1b1d14e75647f191269ac449d87d9ac12506b865 : topLeftCopy
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::bottomRight => _a4085fe64a34efdca9c495374ced14d982a9fcf0 : bottomRight
-_e91898f089a0f9e253c468c6d8d606f38cf85329::bottomRight => _a4085fe64a34efdca9c495374ced14d982a9fcf0 : bottomRight
-_687cda35abd48b9a7e14c54e9ef62d1f9cc080a7::value => _a4085fe64a34efdca9c495374ced14d982a9fcf0 : value
-_d2d6627a35a13caa54370564ee9914486bf006b6::1 => _a4085fe64a34efdca9c495374ced14d982a9fcf0 : 1
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::background => _c782cb251d54e777f73ba090318ea4549ea0154c : background
-_e91898f089a0f9e253c468c6d8d606f38cf85329::backgroundColor => _c782cb251d54e777f73ba090318ea4549ea0154c : backgroundColor
-_c782cb251d54e777f73ba090318ea4549ea0154c::hexValue => _ddc022e583fa6f700df84118a557f6ee593d0896 : hexValue
-_c782cb251d54e777f73ba090318ea4549ea0154c::name => _68f417e07413646bc6802be73fa896ef65e71986 : name
-_c782cb251d54e777f73ba090318ea4549ea0154c::textValue => _2fc96ff8cf245465ff831587cf4c032a1fee1ecb : textValue
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::border => _83b1db9c519c2b87f16cd319822b17b3c6a62a8e : border
-_e91898f089a0f9e253c468c6d8d606f38cf85329::borderColor => _83b1db9c519c2b87f16cd319822b17b3c6a62a8e : borderColor
-_83b1db9c519c2b87f16cd319822b17b3c6a62a8e::hexValue => _f38dba1e51caf683679520a6946afc772ac2222d : hexValue
-_83b1db9c519c2b87f16cd319822b17b3c6a62a8e::name => _ed9882efaf59d7dfde3338f3304ac8f964ed8375 : name
-_83b1db9c519c2b87f16cd319822b17b3c6a62a8e::textValue => _4593e280546f904a7f1a2b3c5cfa43d8ae500f53 : textValue
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::text => _33682ad97510072b61183de7a4bb48da0e39b0b1 : text
-_e91898f089a0f9e253c468c6d8d606f38cf85329::text => _33682ad97510072b61183de7a4bb48da0e39b0b1 : text
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::rect => _e91898f089a0f9e253c468c6d8d606f38cf85329 : rect
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::map => _86d2b65f32348774927a79d7a31769d7e10f45e3 : map
-_86d2b65f32348774927a79d7a31769d7e10f45e3::0 => _a21cb739419a4eaab8ba844909b45dd76458437f : 0
-_a21cb739419a4eaab8ba844909b45dd76458437f::key => _cd6760fb5af30e8ebf4ff44f153961f212af9bb5 : key
-_86d2b65f32348774927a79d7a31769d7e10f45e3::1 => _1163868589bb43fc94f11464b480fbb3e9138123 : 1
-_1163868589bb43fc94f11464b480fbb3e9138123::key => _34de41e50bb069b8e9e78b1b7731121eb4debf9c : key
-_86d2b65f32348774927a79d7a31769d7e10f45e3::2 => _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7 : 2
-_687cda35abd48b9a7e14c54e9ef62d1f9cc080a7::key => _9ec248d870dc55767f1de0ba3545ed57f767a43c : key
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::intArray => _26cb8f97b39839eb7ae52c25f2f8d102403660b5 : intArray
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::stringArray => _71d4b85b1d4247e6d2f27d76c2384fefeec170bd : stringArray
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::points => _d2d6627a35a13caa54370564ee9914486bf006b6 : points
-_d2d6627a35a13caa54370564ee9914486bf006b6::0 => _19700cd8fd1b87bef6d2046533a6afbb10c87d0a : 0
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::topLeftCopy => _1b1d14e75647f191269ac449d87d9ac12506b865
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::bottomRight => _a4085fe64a34efdca9c495374ced14d982a9fcf0
+_e91898f089a0f9e253c468c6d8d606f38cf85329::bottomRight => _a4085fe64a34efdca9c495374ced14d982a9fcf0
+_687cda35abd48b9a7e14c54e9ef62d1f9cc080a7::value => _a4085fe64a34efdca9c495374ced14d982a9fcf0
+_d2d6627a35a13caa54370564ee9914486bf006b6::1 => _a4085fe64a34efdca9c495374ced14d982a9fcf0
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::background => _c782cb251d54e777f73ba090318ea4549ea0154c
+_e91898f089a0f9e253c468c6d8d606f38cf85329::backgroundColor => _c782cb251d54e777f73ba090318ea4549ea0154c
+_c782cb251d54e777f73ba090318ea4549ea0154c::hexValue => _ddc022e583fa6f700df84118a557f6ee593d0896
+_c782cb251d54e777f73ba090318ea4549ea0154c::name => _68f417e07413646bc6802be73fa896ef65e71986
+_c782cb251d54e777f73ba090318ea4549ea0154c::textValue => _2fc96ff8cf245465ff831587cf4c032a1fee1ecb
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::border => _83b1db9c519c2b87f16cd319822b17b3c6a62a8e
+_e91898f089a0f9e253c468c6d8d606f38cf85329::borderColor => _83b1db9c519c2b87f16cd319822b17b3c6a62a8e
+_83b1db9c519c2b87f16cd319822b17b3c6a62a8e::hexValue => _f38dba1e51caf683679520a6946afc772ac2222d
+_83b1db9c519c2b87f16cd319822b17b3c6a62a8e::name => _ed9882efaf59d7dfde3338f3304ac8f964ed8375
+_83b1db9c519c2b87f16cd319822b17b3c6a62a8e::textValue => _4593e280546f904a7f1a2b3c5cfa43d8ae500f53
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::text => _33682ad97510072b61183de7a4bb48da0e39b0b1
+_e91898f089a0f9e253c468c6d8d606f38cf85329::text => _33682ad97510072b61183de7a4bb48da0e39b0b1
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::rect => _e91898f089a0f9e253c468c6d8d606f38cf85329
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::map => _86d2b65f32348774927a79d7a31769d7e10f45e3
+_86d2b65f32348774927a79d7a31769d7e10f45e3::0 => _a21cb739419a4eaab8ba844909b45dd76458437f
+_a21cb739419a4eaab8ba844909b45dd76458437f::key => _cd6760fb5af30e8ebf4ff44f153961f212af9bb5
+_86d2b65f32348774927a79d7a31769d7e10f45e3::1 => _1163868589bb43fc94f11464b480fbb3e9138123
+_1163868589bb43fc94f11464b480fbb3e9138123::key => _34de41e50bb069b8e9e78b1b7731121eb4debf9c
+_86d2b65f32348774927a79d7a31769d7e10f45e3::2 => _687cda35abd48b9a7e14c54e9ef62d1f9cc080a7
+_687cda35abd48b9a7e14c54e9ef62d1f9cc080a7::key => _9ec248d870dc55767f1de0ba3545ed57f767a43c
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::intArray => _26cb8f97b39839eb7ae52c25f2f8d102403660b5
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::stringArray => _71d4b85b1d4247e6d2f27d76c2384fefeec170bd
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::points => _d2d6627a35a13caa54370564ee9914486bf006b6
+_d2d6627a35a13caa54370564ee9914486bf006b6::0 => _19700cd8fd1b87bef6d2046533a6afbb10c87d0a
 @enduml

--- a/src/object-diagram/logic/test-suites/no-variables/tests/default/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/no-variables/tests/default/object-diagram.json
@@ -2,7 +2,6 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     }
   ],

--- a/src/object-diagram/logic/test-suites/no-variables/tests/default/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/no-variables/tests/default/writer/expected.gv
@@ -1,6 +1,6 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
   </table>>]
 }

--- a/src/object-diagram/logic/test-suites/no-variables/tests/default/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/no-variables/tests/default/writer/expected.puml
@@ -1,4 +1,4 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
 }
 @enduml

--- a/src/object-diagram/logic/test-suites/primitive-array-types/tests/object/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/primitive-array-types/tests/object/object-diagram.json
@@ -2,60 +2,50 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_0f7c198c39679a29377285861c0eab7b301f672d",
-      "type": "PrimitiveArrayTypesDemo$FieldContainer",
-      "name": "PrimitiveArrayTypesDemo$FieldContainer@27 \"FieldContainer[booleans=[Z@355da254, bytes=[B@4dc63996, chars=[C@d716361, shorts=[S@6ff3c5b5, ints=[I@3764951d, longs=[J@4b1210ee, floats=[F@4d7e1886, doubles=[D@3cd1a2f1]\""
+      "type": "PrimitiveArrayTypesDemo$FieldContainer"
     },
     {
       "id": "_b154bfeb1a9320d40888ff4cdef84d83c4a0763e",
       "type": "boolean[]",
-      "name": "boolean[1]@9",
       "value": "[false]"
     },
     {
       "id": "_dd7b1158113ccb66341b847e268104fd10a73f08",
       "type": "byte[]",
-      "name": "byte[1]@10",
       "value": "[0]"
     },
     {
       "id": "_107a7f5ab9da095e7ebc472daf37a4b638129ed8",
       "type": "char[]",
-      "name": "char[1]@11",
       "value": "[\\u0000]"
     },
     {
       "id": "_8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e",
       "type": "double[]",
-      "name": "double[1]@16",
       "value": "[0.000000]"
     },
     {
       "id": "_a2d4f1721001eb4a4a134b6572cef2f2015c2280",
       "type": "float[]",
-      "name": "float[1]@15",
       "value": "[0.000000]"
     },
     {
       "id": "_b44837f8cf9531d95542f988ac73cd2a7cfe6bc2",
       "type": "int[]",
-      "name": "int[1]@13",
       "value": "[0]"
     },
     {
       "id": "_fcfd466207315f120afc973f533b6ed01d5330bc",
       "type": "long[]",
-      "name": "long[1]@14",
       "value": "[0]"
     },
     {
       "id": "_fad48851f910c6ef0f8c63d5e047b6288c977977",
       "type": "short[]",
-      "name": "short[1]@12",
       "value": "[0]"
     }
   ],

--- a/src/object-diagram/logic/test-suites/primitive-array-types/tests/object/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/primitive-array-types/tests/object/writer/expected.gv
@@ -1,11 +1,11 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">fieldContainer</td><td align="left" port="fieldContainer"></td></tr>
   </table>>]
   _0f7c198c39679a29377285861c0eab7b301f672d [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>PrimitiveArrayTypesDemo$FieldContainer@27 "FieldContainer[booleans=[Z@355da254, bytes=[B@4dc63996, chars=[C@d716361, shorts=[S@6ff3c5b5, ints=[I@3764951d, longs=[J@4b1210ee, floats=[F@4d7e1886, doubles=[D@3cd1a2f1]"</b><br/><i>&lt;&lt;PrimitiveArrayTypesDemo$FieldContainer&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;PrimitiveArrayTypesDemo$FieldContainer&gt;&gt;</i></td></th>
     <tr><td align="left">booleans</td><td align="left" port="booleans"></td></tr>
     <tr><td align="left">bytes</td><td align="left" port="bytes"></td></tr>
     <tr><td align="left">chars</td><td align="left" port="chars"></td></tr>
@@ -16,44 +16,44 @@ digraph ObjectDiagram {
     <tr><td align="left">shorts</td><td align="left" port="shorts"></td></tr>
   </table>>]
   _b154bfeb1a9320d40888ff4cdef84d83c4a0763e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>boolean[1]@9</b><br/><i>&lt;&lt;boolean[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;boolean[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[false]</td></tr>
   </table>>]
   _dd7b1158113ccb66341b847e268104fd10a73f08 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>byte[1]@10</b><br/><i>&lt;&lt;byte[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;byte[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _107a7f5ab9da095e7ebc472daf37a4b638129ed8 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>char[1]@11</b><br/><i>&lt;&lt;char[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;char[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[\u0000]</td></tr>
   </table>>]
   _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>double[1]@16</b><br/><i>&lt;&lt;double[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;double[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0.000000]</td></tr>
   </table>>]
   _a2d4f1721001eb4a4a134b6572cef2f2015c2280 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>float[1]@15</b><br/><i>&lt;&lt;float[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;float[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0.000000]</td></tr>
   </table>>]
   _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>int[1]@13</b><br/><i>&lt;&lt;int[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;int[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _fcfd466207315f120afc973f533b6ed01d5330bc [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>long[1]@14</b><br/><i>&lt;&lt;long[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;long[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _fad48851f910c6ef0f8c63d5e047b6288c977977 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>short[1]@12</b><br/><i>&lt;&lt;short[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;short[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:fieldContainer -> _0f7c198c39679a29377285861c0eab7b301f672d [label="fieldContainer"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:booleans -> _b154bfeb1a9320d40888ff4cdef84d83c4a0763e [label="booleans"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:bytes -> _dd7b1158113ccb66341b847e268104fd10a73f08 [label="bytes"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:chars -> _107a7f5ab9da095e7ebc472daf37a4b638129ed8 [label="chars"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:doubles -> _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e [label="doubles"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:floats -> _a2d4f1721001eb4a4a134b6572cef2f2015c2280 [label="floats"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:ints -> _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 [label="ints"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:longs -> _fcfd466207315f120afc973f533b6ed01d5330bc [label="longs"]
-  _0f7c198c39679a29377285861c0eab7b301f672d:shorts -> _fad48851f910c6ef0f8c63d5e047b6288c977977 [label="shorts"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:fieldContainer -> _0f7c198c39679a29377285861c0eab7b301f672d
+  _0f7c198c39679a29377285861c0eab7b301f672d:booleans -> _b154bfeb1a9320d40888ff4cdef84d83c4a0763e
+  _0f7c198c39679a29377285861c0eab7b301f672d:bytes -> _dd7b1158113ccb66341b847e268104fd10a73f08
+  _0f7c198c39679a29377285861c0eab7b301f672d:chars -> _107a7f5ab9da095e7ebc472daf37a4b638129ed8
+  _0f7c198c39679a29377285861c0eab7b301f672d:doubles -> _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e
+  _0f7c198c39679a29377285861c0eab7b301f672d:floats -> _a2d4f1721001eb4a4a134b6572cef2f2015c2280
+  _0f7c198c39679a29377285861c0eab7b301f672d:ints -> _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2
+  _0f7c198c39679a29377285861c0eab7b301f672d:longs -> _fcfd466207315f120afc973f533b6ed01d5330bc
+  _0f7c198c39679a29377285861c0eab7b301f672d:shorts -> _fad48851f910c6ef0f8c63d5e047b6288c977977
 }

--- a/src/object-diagram/logic/test-suites/primitive-array-types/tests/object/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/primitive-array-types/tests/object/writer/expected.puml
@@ -1,8 +1,8 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   fieldContainer =>
 }
-map "PrimitiveArrayTypesDemo$FieldContainer@27 <U+0022>FieldContainer[booleans=[Z@355da254, bytes=[B@4dc63996, chars=[C@d716361, shorts=[S@6ff3c5b5, ints=[I@3764951d, longs=[J@4b1210ee, floats=[F@4d7e1886, doubles=[D@3cd1a2f1]<U+0022>" as _0f7c198c39679a29377285861c0eab7b301f672d <<PrimitiveArrayTypesDemo$FieldContainer>> {
+map "<<PrimitiveArrayTypesDemo$FieldContainer>>" as _0f7c198c39679a29377285861c0eab7b301f672d {
   booleans =>
   bytes =>
   chars =>
@@ -12,37 +12,37 @@ map "PrimitiveArrayTypesDemo$FieldContainer@27 <U+0022>FieldContainer[booleans=[
   longs =>
   shorts =>
 }
-object "boolean[1]@9" as _b154bfeb1a9320d40888ff4cdef84d83c4a0763e <<boolean[]>> {
+object "<<boolean[]>>" as _b154bfeb1a9320d40888ff4cdef84d83c4a0763e {
   [false]
 }
-object "byte[1]@10" as _dd7b1158113ccb66341b847e268104fd10a73f08 <<byte[]>> {
+object "<<byte[]>>" as _dd7b1158113ccb66341b847e268104fd10a73f08 {
   [0]
 }
-object "char[1]@11" as _107a7f5ab9da095e7ebc472daf37a4b638129ed8 <<char[]>> {
+object "<<char[]>>" as _107a7f5ab9da095e7ebc472daf37a4b638129ed8 {
   [\u0000]
 }
-object "double[1]@16" as _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e <<double[]>> {
+object "<<double[]>>" as _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e {
   [0.000000]
 }
-object "float[1]@15" as _a2d4f1721001eb4a4a134b6572cef2f2015c2280 <<float[]>> {
+object "<<float[]>>" as _a2d4f1721001eb4a4a134b6572cef2f2015c2280 {
   [0.000000]
 }
-object "int[1]@13" as _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 <<int[]>> {
+object "<<int[]>>" as _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 {
   [0]
 }
-object "long[1]@14" as _fcfd466207315f120afc973f533b6ed01d5330bc <<long[]>> {
+object "<<long[]>>" as _fcfd466207315f120afc973f533b6ed01d5330bc {
   [0]
 }
-object "short[1]@12" as _fad48851f910c6ef0f8c63d5e047b6288c977977 <<short[]>> {
+object "<<short[]>>" as _fad48851f910c6ef0f8c63d5e047b6288c977977 {
   [0]
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::fieldContainer => _0f7c198c39679a29377285861c0eab7b301f672d : fieldContainer
-_0f7c198c39679a29377285861c0eab7b301f672d::booleans => _b154bfeb1a9320d40888ff4cdef84d83c4a0763e : booleans
-_0f7c198c39679a29377285861c0eab7b301f672d::bytes => _dd7b1158113ccb66341b847e268104fd10a73f08 : bytes
-_0f7c198c39679a29377285861c0eab7b301f672d::chars => _107a7f5ab9da095e7ebc472daf37a4b638129ed8 : chars
-_0f7c198c39679a29377285861c0eab7b301f672d::doubles => _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e : doubles
-_0f7c198c39679a29377285861c0eab7b301f672d::floats => _a2d4f1721001eb4a4a134b6572cef2f2015c2280 : floats
-_0f7c198c39679a29377285861c0eab7b301f672d::ints => _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 : ints
-_0f7c198c39679a29377285861c0eab7b301f672d::longs => _fcfd466207315f120afc973f533b6ed01d5330bc : longs
-_0f7c198c39679a29377285861c0eab7b301f672d::shorts => _fad48851f910c6ef0f8c63d5e047b6288c977977 : shorts
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::fieldContainer => _0f7c198c39679a29377285861c0eab7b301f672d
+_0f7c198c39679a29377285861c0eab7b301f672d::booleans => _b154bfeb1a9320d40888ff4cdef84d83c4a0763e
+_0f7c198c39679a29377285861c0eab7b301f672d::bytes => _dd7b1158113ccb66341b847e268104fd10a73f08
+_0f7c198c39679a29377285861c0eab7b301f672d::chars => _107a7f5ab9da095e7ebc472daf37a4b638129ed8
+_0f7c198c39679a29377285861c0eab7b301f672d::doubles => _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e
+_0f7c198c39679a29377285861c0eab7b301f672d::floats => _a2d4f1721001eb4a4a134b6572cef2f2015c2280
+_0f7c198c39679a29377285861c0eab7b301f672d::ints => _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2
+_0f7c198c39679a29377285861c0eab7b301f672d::longs => _fcfd466207315f120afc973f533b6ed01d5330bc
+_0f7c198c39679a29377285861c0eab7b301f672d::shorts => _fad48851f910c6ef0f8c63d5e047b6288c977977
 @enduml

--- a/src/object-diagram/logic/test-suites/primitive-array-types/tests/stack-frame/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/primitive-array-types/tests/stack-frame/object-diagram.json
@@ -2,61 +2,51 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     },
     {
       "id": "_b154bfeb1a9320d40888ff4cdef84d83c4a0763e",
       "type": "boolean[]",
-      "name": "boolean[1]@9",
       "value": "[false]"
     },
     {
       "id": "_dd7b1158113ccb66341b847e268104fd10a73f08",
       "type": "byte[]",
-      "name": "byte[1]@10",
       "value": "[0]"
     },
     {
       "id": "_107a7f5ab9da095e7ebc472daf37a4b638129ed8",
       "type": "char[]",
-      "name": "char[1]@11",
       "value": "[\\u0000]"
     },
     {
       "id": "_fad48851f910c6ef0f8c63d5e047b6288c977977",
       "type": "short[]",
-      "name": "short[1]@12",
       "value": "[0]"
     },
     {
       "id": "_b44837f8cf9531d95542f988ac73cd2a7cfe6bc2",
       "type": "int[]",
-      "name": "int[1]@13",
       "value": "[0]"
     },
     {
       "id": "_fcfd466207315f120afc973f533b6ed01d5330bc",
       "type": "long[]",
-      "name": "long[1]@14",
       "value": "[0]"
     },
     {
       "id": "_a2d4f1721001eb4a4a134b6572cef2f2015c2280",
       "type": "float[]",
-      "name": "float[1]@15",
       "value": "[0.000000]"
     },
     {
       "id": "_8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e",
       "type": "double[]",
-      "name": "double[1]@16",
       "value": "[0.000000]"
     }
   ],

--- a/src/object-diagram/logic/test-suites/primitive-array-types/tests/stack-frame/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/primitive-array-types/tests/stack-frame/writer/expected.gv
@@ -1,7 +1,7 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
     <tr><td align="left">booleans</td><td align="left" port="booleans"></td></tr>
     <tr><td align="left">bytes</td><td align="left" port="bytes"></td></tr>
@@ -13,48 +13,48 @@ digraph ObjectDiagram {
     <tr><td align="left">doubles</td><td align="left" port="doubles"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
   _b154bfeb1a9320d40888ff4cdef84d83c4a0763e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>boolean[1]@9</b><br/><i>&lt;&lt;boolean[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;boolean[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[false]</td></tr>
   </table>>]
   _dd7b1158113ccb66341b847e268104fd10a73f08 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>byte[1]@10</b><br/><i>&lt;&lt;byte[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;byte[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _107a7f5ab9da095e7ebc472daf37a4b638129ed8 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>char[1]@11</b><br/><i>&lt;&lt;char[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;char[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[\u0000]</td></tr>
   </table>>]
   _fad48851f910c6ef0f8c63d5e047b6288c977977 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>short[1]@12</b><br/><i>&lt;&lt;short[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;short[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>int[1]@13</b><br/><i>&lt;&lt;int[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;int[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _fcfd466207315f120afc973f533b6ed01d5330bc [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>long[1]@14</b><br/><i>&lt;&lt;long[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;long[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0]</td></tr>
   </table>>]
   _a2d4f1721001eb4a4a134b6572cef2f2015c2280 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>float[1]@15</b><br/><i>&lt;&lt;float[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;float[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0.000000]</td></tr>
   </table>>]
   _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>double[1]@16</b><br/><i>&lt;&lt;double[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;double[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[0.000000]</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:booleans -> _b154bfeb1a9320d40888ff4cdef84d83c4a0763e [label="booleans"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:bytes -> _dd7b1158113ccb66341b847e268104fd10a73f08 [label="bytes"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:chars -> _107a7f5ab9da095e7ebc472daf37a4b638129ed8 [label="chars"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:shorts -> _fad48851f910c6ef0f8c63d5e047b6288c977977 [label="shorts"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:ints -> _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 [label="ints"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:longs -> _fcfd466207315f120afc973f533b6ed01d5330bc [label="longs"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:floats -> _a2d4f1721001eb4a4a134b6572cef2f2015c2280 [label="floats"]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:doubles -> _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e [label="doubles"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:booleans -> _b154bfeb1a9320d40888ff4cdef84d83c4a0763e
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:bytes -> _dd7b1158113ccb66341b847e268104fd10a73f08
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:chars -> _107a7f5ab9da095e7ebc472daf37a4b638129ed8
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:shorts -> _fad48851f910c6ef0f8c63d5e047b6288c977977
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:ints -> _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:longs -> _fcfd466207315f120afc973f533b6ed01d5330bc
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:floats -> _a2d4f1721001eb4a4a134b6572cef2f2015c2280
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:doubles -> _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e
 }

--- a/src/object-diagram/logic/test-suites/primitive-array-types/tests/stack-frame/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/primitive-array-types/tests/stack-frame/writer/expected.puml
@@ -1,5 +1,5 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   args =>
   booleans =>
   bytes =>
@@ -10,40 +10,40 @@ map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>>
   floats =>
   doubles =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-object "boolean[1]@9" as _b154bfeb1a9320d40888ff4cdef84d83c4a0763e <<boolean[]>> {
+object "<<boolean[]>>" as _b154bfeb1a9320d40888ff4cdef84d83c4a0763e {
   [false]
 }
-object "byte[1]@10" as _dd7b1158113ccb66341b847e268104fd10a73f08 <<byte[]>> {
+object "<<byte[]>>" as _dd7b1158113ccb66341b847e268104fd10a73f08 {
   [0]
 }
-object "char[1]@11" as _107a7f5ab9da095e7ebc472daf37a4b638129ed8 <<char[]>> {
+object "<<char[]>>" as _107a7f5ab9da095e7ebc472daf37a4b638129ed8 {
   [\u0000]
 }
-object "short[1]@12" as _fad48851f910c6ef0f8c63d5e047b6288c977977 <<short[]>> {
+object "<<short[]>>" as _fad48851f910c6ef0f8c63d5e047b6288c977977 {
   [0]
 }
-object "int[1]@13" as _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 <<int[]>> {
+object "<<int[]>>" as _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 {
   [0]
 }
-object "long[1]@14" as _fcfd466207315f120afc973f533b6ed01d5330bc <<long[]>> {
+object "<<long[]>>" as _fcfd466207315f120afc973f533b6ed01d5330bc {
   [0]
 }
-object "float[1]@15" as _a2d4f1721001eb4a4a134b6572cef2f2015c2280 <<float[]>> {
+object "<<float[]>>" as _a2d4f1721001eb4a4a134b6572cef2f2015c2280 {
   [0.000000]
 }
-object "double[1]@16" as _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e <<double[]>> {
+object "<<double[]>>" as _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e {
   [0.000000]
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::booleans => _b154bfeb1a9320d40888ff4cdef84d83c4a0763e : booleans
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::bytes => _dd7b1158113ccb66341b847e268104fd10a73f08 : bytes
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::chars => _107a7f5ab9da095e7ebc472daf37a4b638129ed8 : chars
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::shorts => _fad48851f910c6ef0f8c63d5e047b6288c977977 : shorts
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::ints => _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2 : ints
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::longs => _fcfd466207315f120afc973f533b6ed01d5330bc : longs
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::floats => _a2d4f1721001eb4a4a134b6572cef2f2015c2280 : floats
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::doubles => _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e : doubles
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::booleans => _b154bfeb1a9320d40888ff4cdef84d83c4a0763e
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::bytes => _dd7b1158113ccb66341b847e268104fd10a73f08
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::chars => _107a7f5ab9da095e7ebc472daf37a4b638129ed8
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::shorts => _fad48851f910c6ef0f8c63d5e047b6288c977977
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::ints => _b44837f8cf9531d95542f988ac73cd2a7cfe6bc2
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::longs => _fcfd466207315f120afc973f533b6ed01d5330bc
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::floats => _a2d4f1721001eb4a4a134b6572cef2f2015c2280
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::doubles => _8aab52297f8c7f19a95f5ce7a264c03b1cea2d1e
 @enduml

--- a/src/object-diagram/logic/test-suites/primitive-types/tests/object/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/primitive-types/tests/object/object-diagram.json
@@ -2,13 +2,11 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_ea0aca3bedbad950e9d8b35c1bab07af352d76c4",
-      "type": "PrimitiveTypesDemo$FieldContainer",
-      "name": "PrimitiveTypesDemo$FieldContainer@11 \"FieldContainer[_boolean=false, _byte=0, _char=\\u0000, _short=0, _int=0, _long=0, _float=0.0, _double=0.0]\""
+      "type": "PrimitiveTypesDemo$FieldContainer"
     }
   ],
   "fields": [

--- a/src/object-diagram/logic/test-suites/primitive-types/tests/object/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/primitive-types/tests/object/writer/expected.gv
@@ -1,11 +1,11 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">fieldContainer</td><td align="left" port="fieldContainer"></td></tr>
   </table>>]
   _ea0aca3bedbad950e9d8b35c1bab07af352d76c4 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>PrimitiveTypesDemo$FieldContainer@11 "FieldContainer[_boolean=false, _byte=0, _char=\u0000, _short=0, _int=0, _long=0, _float=0.0, _double=0.0]"</b><br/><i>&lt;&lt;PrimitiveTypesDemo$FieldContainer&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;PrimitiveTypesDemo$FieldContainer&gt;&gt;</i></td></th>
     <tr><td align="left">_boolean</td><td align="left" port="_boolean">false (boolean)</td></tr>
     <tr><td align="left">_byte</td><td align="left" port="_byte">0 (byte)</td></tr>
     <tr><td align="left">_char</td><td align="left" port="_char">\u0000 (char)</td></tr>
@@ -15,5 +15,5 @@ digraph ObjectDiagram {
     <tr><td align="left">_long</td><td align="left" port="_long">0 (long)</td></tr>
     <tr><td align="left">_short</td><td align="left" port="_short">0 (short)</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:fieldContainer -> _ea0aca3bedbad950e9d8b35c1bab07af352d76c4 [label="fieldContainer"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:fieldContainer -> _ea0aca3bedbad950e9d8b35c1bab07af352d76c4
 }

--- a/src/object-diagram/logic/test-suites/primitive-types/tests/object/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/primitive-types/tests/object/writer/expected.puml
@@ -1,8 +1,8 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   fieldContainer =>
 }
-map "PrimitiveTypesDemo$FieldContainer@11 <U+0022>FieldContainer[_boolean=false, _byte=0, _char=\u0000, _short=0, _int=0, _long=0, _float=0.0, _double=0.0]<U+0022>" as _ea0aca3bedbad950e9d8b35c1bab07af352d76c4 <<PrimitiveTypesDemo$FieldContainer>> {
+map "<<PrimitiveTypesDemo$FieldContainer>>" as _ea0aca3bedbad950e9d8b35c1bab07af352d76c4 {
   _boolean => false (boolean)
   _byte => 0 (byte)
   _char => \u0000 (char)
@@ -12,5 +12,5 @@ map "PrimitiveTypesDemo$FieldContainer@11 <U+0022>FieldContainer[_boolean=false,
   _long => 0 (long)
   _short => 0 (short)
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::fieldContainer => _ea0aca3bedbad950e9d8b35c1bab07af352d76c4 : fieldContainer
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::fieldContainer => _ea0aca3bedbad950e9d8b35c1bab07af352d76c4
 @enduml

--- a/src/object-diagram/logic/test-suites/primitive-types/tests/stack-frame/object-diagram.json
+++ b/src/object-diagram/logic/test-suites/primitive-types/tests/stack-frame/object-diagram.json
@@ -2,13 +2,11 @@
   "structures": [
     {
       "id": "_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352",
-      "name": "[StackFrame]",
       "type": "[StackFrame]"
     },
     {
       "id": "_482d9dec6ff954d68d94793f765be61dbc59cb47",
       "type": "String[]",
-      "name": "String[0]@8",
       "value": "[]"
     }
   ],

--- a/src/object-diagram/logic/test-suites/primitive-types/tests/stack-frame/writer/expected.gv
+++ b/src/object-diagram/logic/test-suites/primitive-types/tests/stack-frame/writer/expected.gv
@@ -1,7 +1,7 @@
 digraph ObjectDiagram {
   node [shape=plaintext]
   _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>[StackFrame]</b><br/><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;[StackFrame]&gt;&gt;</i></td></th>
     <tr><td align="left">_boolean</td><td align="left" port="_boolean">false (boolean)</td></tr>
     <tr><td align="left">_byte</td><td align="left" port="_byte">0 (byte)</td></tr>
     <tr><td align="left">_char</td><td align="left" port="_char">\u0000 (char)</td></tr>
@@ -13,8 +13,8 @@ digraph ObjectDiagram {
     <tr><td align="left">args</td><td align="left" port="args"></td></tr>
   </table>>]
   _482d9dec6ff954d68d94793f765be61dbc59cb47 [label=<<table border="0" cellborder="1" cellspacing="0">
-    <th><td colspan="2"><b>String[0]@8</b><br/><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
+    <th><td colspan="2"><i>&lt;&lt;String[]&gt;&gt;</i></td></th>
     <tr><td colspan="2">[]</td></tr>
   </table>>]
-  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47 [label="args"]
+  _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352:args -> _482d9dec6ff954d68d94793f765be61dbc59cb47
 }

--- a/src/object-diagram/logic/test-suites/primitive-types/tests/stack-frame/writer/expected.puml
+++ b/src/object-diagram/logic/test-suites/primitive-types/tests/stack-frame/writer/expected.puml
@@ -1,5 +1,5 @@
 @startuml
-map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>> {
+map "<<[StackFrame]>>" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 {
   _boolean => false (boolean)
   _byte => 0 (byte)
   _char => \u0000 (char)
@@ -10,8 +10,8 @@ map "[StackFrame]" as _0f07b6f2a31cbd2e26428c51e8660b0dffe6e352 <<[StackFrame]>>
   _double => 0.000000 (double)
   args =>
 }
-object "String[0]@8" as _482d9dec6ff954d68d94793f765be61dbc59cb47 <<String[]>> {
+object "<<String[]>>" as _482d9dec6ff954d68d94793f765be61dbc59cb47 {
   []
 }
-_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47 : args
+_0f07b6f2a31cbd2e26428c51e8660b0dffe6e352::args => _482d9dec6ff954d68d94793f765be61dbc59cb47
 @enduml

--- a/src/object-diagram/logic/writer/graphVizObjectDiagramWriter.ts
+++ b/src/object-diagram/logic/writer/graphVizObjectDiagramWriter.ts
@@ -7,9 +7,9 @@ export class GraphVizObjectDiagramWriter extends ObjectDiagramWriter {
     yield 'digraph ObjectDiagram {';
     yield '  node [shape=plaintext]';
   }
-  protected *generateStructureHeaderLines({ id, type, name }: Structure): Generator<string> {
+  protected *generateStructureHeaderLines({ id, type }: Structure): Generator<string> {
     yield `  ${id} [label=<<table border="0" cellborder="1" cellspacing="0">`;
-    yield `    <th><td colspan="2"><b>${name}</b><br/><i>&lt;&lt;${type}&gt;&gt;</i></td></th>`;
+    yield `    <th><td colspan="2"><i>&lt;&lt;${type}&gt;&gt;</i></td></th>`;
   }
   protected *generateStructureValueLines(value: string): Generator<string> {
     yield `    <tr><td colspan="2">${value}</td></tr>`;
@@ -21,7 +21,7 @@ export class GraphVizObjectDiagramWriter extends ObjectDiagramWriter {
     yield '  </table>>]';
   }
   protected *generateReferenceDeclarationLines({ startId, endId, name }: Reference): Generator<string> {
-    yield `  ${startId}:${name} -> ${endId} [label="${name}"]`;
+    yield `  ${startId}:${name} -> ${endId}`;
   }
   protected *generateFooterLines(): Generator<string> {
     yield '}';

--- a/src/object-diagram/logic/writer/plantUmlObjectDiagramWriter.ts
+++ b/src/object-diagram/logic/writer/plantUmlObjectDiagramWriter.ts
@@ -2,14 +2,12 @@ import { Reference } from '../../model/reference';
 import { Structure } from '../../model/structure';
 import { ObjectDiagramWriter } from './objectDiagramWriter';
 
-const escapeDoubleQuotes = (name: string): string => name.replace(/"/g, '<U+0022>');
-
 export class PlantUmlObjectDiagramWriter extends ObjectDiagramWriter {
   protected *generateHeaderLines(): Generator<string> {
     yield '@startuml';
   }
-  protected *generateStructureHeaderLines({ id, type, name, value }: Structure): Generator<string> {
-    yield `${value ? 'object' : 'map'} "${escapeDoubleQuotes(name)}" as ${id} <<${type}>> {`;
+  protected *generateStructureHeaderLines({ id, type, value }: Structure): Generator<string> {
+    yield `${value ? 'object' : 'map'} "<<${type}>>" as ${id} {`;
   }
   protected *generateStructureValueLines(value: string): Generator<string> {
     yield `  ${value}`;
@@ -22,7 +20,7 @@ export class PlantUmlObjectDiagramWriter extends ObjectDiagramWriter {
     yield '}';
   }
   protected *generateReferenceDeclarationLines({ startId, endId, name }: Reference): Generator<string> {
-    yield `${startId}::${name} => ${endId} : ${name}`;
+    yield `${startId}::${name} => ${endId}`;
   }
   protected *generateFooterLines(): Generator<string> {
     yield '@enduml';

--- a/src/object-diagram/model/structure.ts
+++ b/src/object-diagram/model/structure.ts
@@ -11,6 +11,5 @@ import { StructureId } from './structureId';
 export interface Structure {
   id: StructureId;
   type: string;
-  name: EscapedString;
   value?: EscapedString;
 }

--- a/src/webview/debuggerPanel.ts
+++ b/src/webview/debuggerPanel.ts
@@ -189,7 +189,7 @@ export class DebuggerPanel {
     return new ObjectDiagramFileSaverFactory(
       new MementoAccessor<string>(memento, 'visual-oo-debugger.lastObjectDiagramExportDirectoryPath'),
       (): ObjectDiagram => {
-        const input = this.currentPanelViewInput;
+        const input = this.currentVariables;
         if (!input) {
           throw new Error('Could not export (no panel view input available)');
         }


### PR DESCRIPTION
* Export selected stackframe
* Only show the type of an object in a node header, since the internal ID doesn't add any usable information
* Remove labels of edges
* Use name of variable instead of id in stackframe node