### PR TITLE
VOOD-188: Ensure initialization of re-opened debugger panels

### DIFF
--- a/src/webview/debuggerPanel.ts
+++ b/src/webview/debuggerPanel.ts
@@ -80,6 +80,7 @@ export class DebuggerPanel {
     void commands.executeCommand('setContext', 'viewPanel.exists', true);
 
     if (this.currentPanelViewInput) {
+      this.currentVariables = undefined;
       this.updatePanel(this.currentPanelViewInput);
     }
   }


### PR DESCRIPTION
VOOD-188

Fixes Issue VOOD-188

## Changes

Ensures initialization of re-opened debugger panels by resetting `DebuggerPanel.currentVariables` to `undefined` before the panel is opened in `DebuggerPanel.openPanel` as there are no previous variables to compute an update in `VisjsPanelView.updatePanel`.
