### PR TITLE
VOOD-181: use Parentid as hash for null values

### DIFF
--- a/src/data-extractor/abstractDataExtractor.ts
+++ b/src/data-extractor/abstractDataExtractor.ts
@@ -12,7 +12,7 @@ export abstract class AbstractDataExtractor {
 
   abstract createPrimitiveVariable(variable: DebugProtocol.Variable): PanelViewVariable;
   abstract createPrimitiveValue(variable: DebugProtocol.Variable): PrimitiveValue;
-  abstract createVariableId(variable: DebugProtocol.Variable): string;
+  abstract createVariableId(variable: DebugProtocol.Variable, parentId?: string | undefined): string;
   abstract createVariableRelation(parentId: string, variable: DebugProtocol.Variable | undefined): VariableRelation;
   abstract createVariableReference(childId: string, variable: DebugProtocol.Variable | undefined): VariableReference;
   abstract createVariableEntryForNamedVariable(referencedObjectId: string, variable: DebugProtocol.Variable): PanelViewVariable;

--- a/src/data-extractor/abstractDataExtractor.ts
+++ b/src/data-extractor/abstractDataExtractor.ts
@@ -12,7 +12,7 @@ export abstract class AbstractDataExtractor {
 
   abstract createPrimitiveVariable(variable: DebugProtocol.Variable): PanelViewVariable;
   abstract createPrimitiveValue(variable: DebugProtocol.Variable): PrimitiveValue;
-  abstract createVariableId(variable: DebugProtocol.Variable, parentId?: string | undefined): string;
+  abstract createVariableId(variable: DebugProtocol.Variable, parentId?: string): string;
   abstract createVariableRelation(parentId: string, variable: DebugProtocol.Variable | undefined): VariableRelation;
   abstract createVariableReference(childId: string, variable: DebugProtocol.Variable | undefined): VariableReference;
   abstract createVariableEntryForNamedVariable(referencedObjectId: string, variable: DebugProtocol.Variable): PanelViewVariable;

--- a/src/data-extractor/javaDataExtractor.spec.ts
+++ b/src/data-extractor/javaDataExtractor.spec.ts
@@ -131,7 +131,7 @@ describe('JavaDataExtractor', () => {
   describe('createVariableId', () => {
     it('should add null_ prefix to null variable', () => {
       const inputVariable = createVariable('null');
-      const expected = `null_${hash(inputVariable)}`;
+      const expected = `null__${inputVariable.name}`;
       expect(dataExtractor.createVariableId(inputVariable)).to.equal(expected);
     });
 

--- a/src/data-extractor/javaDataExtractor.ts
+++ b/src/data-extractor/javaDataExtractor.ts
@@ -47,8 +47,10 @@ export class JavaDataExtractor extends AbstractDataExtractor {
     return { type: variable.type, name: variable.name, value: variable.value };
   }
 
-  createVariableId(variable: DebugProtocol.Variable): string {
-    return this.isNullVariable(variable) ? addNullPrefix(hash(variable)) : addObjectPrefix(variable.value.split(this.sizeSuffix)[0]);
+  createVariableId(variable: DebugProtocol.Variable, parentId?: string | undefined): string {
+    return this.isNullVariable(variable)
+      ? addNullPrefix(hash(parentId ? parentId : variable))
+      : addObjectPrefix(variable.value.split(this.sizeSuffix)[0]);
   }
 
   createVariableRelation(parentId: string, variable: DebugProtocol.Variable | undefined): VariableRelation {

--- a/src/data-extractor/javaDataExtractor.ts
+++ b/src/data-extractor/javaDataExtractor.ts
@@ -49,7 +49,7 @@ export class JavaDataExtractor extends AbstractDataExtractor {
 
   createVariableId(variable: DebugProtocol.Variable, parentId?: string): string {
     return this.isNullVariable(variable)
-      ? addNullPrefix(`${parentId ? parentId : ''}_${variable.name}`)
+      ? addNullPrefix(`${parentId ?? ''}_${variable.name}`)
       : addObjectPrefix(variable.value.split(this.sizeSuffix)[0]);
   }
 

--- a/src/data-extractor/javaDataExtractor.ts
+++ b/src/data-extractor/javaDataExtractor.ts
@@ -47,9 +47,9 @@ export class JavaDataExtractor extends AbstractDataExtractor {
     return { type: variable.type, name: variable.name, value: variable.value };
   }
 
-  createVariableId(variable: DebugProtocol.Variable, parentId?: string | undefined): string {
+  createVariableId(variable: DebugProtocol.Variable, parentId?: string): string {
     return this.isNullVariable(variable)
-      ? addNullPrefix(hash(parentId ? parentId : variable))
+      ? addNullPrefix(`${parentId ? parentId : ''}_${variable.name}`)
       : addObjectPrefix(variable.value.split(this.sizeSuffix)[0]);
   }
 

--- a/src/debug-adapter/debugEventManager.ts
+++ b/src/debug-adapter/debugEventManager.ts
@@ -129,7 +129,7 @@ export class DebugEventManager {
     dataExtractor: AbstractDataExtractor
   ): Promise<void> {
     let isNewAndObject = false;
-    const id = dataExtractor.createVariableId(variable);
+    const id = dataExtractor.createVariableId(variable, parentId);
     let panelViewVariable = panelViewStackFrame.variables.get(id);
     if (panelViewVariable === undefined) {
       [panelViewVariable, isNewAndObject] = await this.createPanelViewVariable(id, variable, debugSessionProxy, dataExtractor);


### PR DESCRIPTION
The Problem was that the id of a null value is the hash of the DebugProtocol.Variable. the Variable contains a field “evaluation name” with the corresponding variable. If the variable is changed the evaluation name changes accordingly and a new id is generated. The value is therefore marked as changed in the vis.js visualization.
In this solution use the parent id as source for the hash if it exists. 
